### PR TITLE
feat(jsruntime): VariableStatement

### DIFF
--- a/libs/jsparser/src/syntax/actions.yaml
+++ b/libs/jsparser/src/syntax/actions.yaml
@@ -131,7 +131,7 @@
 - rule: Statement -> BlockStatement
   action: process_statement
 - rule: Statement -> VariableStatement
-  action: undefined
+  action: process_statement
 - rule: Statement -> EmptyStatement
   action: process_statement
 - rule: Statement -> ExpressionStatement
@@ -211,7 +211,7 @@
 - rule: BlockStatement -> Block
   action: process_block_statement
 - rule: VariableStatement -> VAR VariableDeclarationList_In SEMICOLON
-  action: undefined
+  action: process_variable_statement
 - rule: EmptyStatement -> SEMICOLON
   action: process_empty_statement
 - rule: >-
@@ -297,7 +297,7 @@
 - rule: NamedExports -> LBRACE ExportsList COMMA RBRACE
   action: undefined
 - rule: VariableStatement_Await -> VAR VariableDeclarationList_In_Await SEMICOLON
-  action: undefined
+  action: process_variable_statement
 - rule: Declaration_Await -> HoistableDeclaration_Await
   action: process_declaration
 - rule: Declaration_Await -> ClassDeclaration_Await
@@ -351,7 +351,7 @@
 - rule: Statement_Await -> BlockStatement_Await
   action: process_statement
 - rule: Statement_Await -> VariableStatement_Await
-  action: undefined
+  action: process_statement
 - rule: Statement_Await -> EmptyStatement
   action: process_statement
 - rule: Statement_Await -> ExpressionStatement_Await
@@ -445,11 +445,11 @@
 - rule: Block -> LBRACE _BLOCK_SCOPE_ StatementList RBRACE
   action: process_block
 - rule: VariableDeclarationList_In -> VariableDeclaration_In
-  action: undefined
+  action: process_variable_declaration_list_head
 - rule: >-
     VariableDeclarationList_In -> VariableDeclarationList_In COMMA
     VariableDeclaration_In
-  action: undefined
+  action: process_variable_declaration_list_item
 - rule: Expression_In -> AssignmentExpression_In
   action: nop
 - rule: Expression_In -> Expression_In COMMA AssignmentExpression_In
@@ -542,11 +542,11 @@
 - rule: ExportsList -> ExportsList COMMA ExportSpecifier
   action: undefined
 - rule: VariableDeclarationList_In_Await -> VariableDeclaration_In_Await
-  action: undefined
+  action: process_variable_declaration_list_head
 - rule: >-
     VariableDeclarationList_In_Await -> VariableDeclarationList_In_Await COMMA
     VariableDeclaration_In_Await
-  action: undefined
+  action: process_variable_declaration_list_item
 - rule: HoistableDeclaration_Await -> FunctionDeclaration_Await
   action: process_hoistable_declaration
 - rule: HoistableDeclaration_Await -> GeneratorDeclaration_Await
@@ -907,11 +907,11 @@
 - rule: _BLOCK_SCOPE_ -> (empty)
   action: process_block_scope
 - rule: VariableDeclaration_In -> BindingIdentifier
-  action: undefined
+  action: process_variable_declaration_no_init
 - rule: VariableDeclaration_In -> BindingIdentifier Initializer_In
-  action: undefined
+  action: process_variable_declaration
 - rule: VariableDeclaration_In -> BindingPattern Initializer_In
-  action: undefined
+  action: process_variable_declaration_pattern
 - rule: AssignmentExpression_In -> ConditionalExpression_In
   action: nop
 - rule: AssignmentExpression_In -> ArrowFunction_In
@@ -1207,11 +1207,11 @@
 - rule: ExportSpecifier -> ModuleExportName AS ModuleExportName
   action: undefined
 - rule: VariableDeclaration_In_Await -> BindingIdentifier_Await
-  action: undefined
+  action: process_variable_declaration_no_init
 - rule: VariableDeclaration_In_Await -> BindingIdentifier_Await Initializer_In_Await
-  action: undefined
+  action: process_variable_declaration
 - rule: VariableDeclaration_In_Await -> BindingPattern_Await Initializer_In_Await
-  action: undefined
+  action: process_variable_declaration_pattern
 - rule: >-
     FunctionDeclaration_Await -> FUNCTION BindingIdentifier_Await
     _FUNCTION_CONTEXT_ LPAREN FormalParameters RPAREN _FUNCTION_SIGNATURE_
@@ -1521,9 +1521,9 @@
 - rule: _LOOP_NEXT_ -> (empty)
   action: process_loop_next
 - rule: VariableDeclarationList -> VariableDeclaration
-  action: undefined
+  action: process_variable_declaration_list_head
 - rule: VariableDeclarationList -> VariableDeclarationList COMMA VariableDeclaration
-  action: undefined
+  action: process_variable_declaration_list_item
 - rule: _LOOP_INIT_VAR_DECLARATION_ -> (empty)
   action: process_loop_init_var_declaration
 - rule: LexicalDeclaration -> LET BindingList SEMICOLON
@@ -1992,11 +1992,11 @@
     _NULLISH_SHORT_CIRCUIT_ASSIGNMENT_ AssignmentExpression _DEREFERENCE_
   action: process_nullish_coalescing_assignment
 - rule: VariableDeclaration -> BindingIdentifier
-  action: undefined
+  action: process_variable_declaration_no_init
 - rule: VariableDeclaration -> BindingIdentifier Initializer
-  action: undefined
+  action: process_variable_declaration
 - rule: VariableDeclaration -> BindingPattern Initializer
-  action: undefined
+  action: process_variable_declaration_pattern
 - rule: BindingList -> LexicalBinding
   action: process_binding_list_head
 - rule: BindingList -> BindingList COMMA LexicalBinding
@@ -2122,11 +2122,11 @@
 - rule: Expression_Await -> Expression_Await COMMA AssignmentExpression_Await
   action: process_comma_operator
 - rule: VariableDeclarationList_Await -> VariableDeclaration_Await
-  action: undefined
+  action: process_variable_declaration_list_head
 - rule: >-
     VariableDeclarationList_Await -> VariableDeclarationList_Await COMMA
     VariableDeclaration_Await
-  action: undefined
+  action: process_variable_declaration_list_item
 - rule: LexicalDeclaration_Await -> LET BindingList_Await SEMICOLON
   action: process_let_declaration
 - rule: LexicalDeclaration_Await -> CONST BindingList_Await SEMICOLON
@@ -2564,11 +2564,11 @@
     _NULLISH_SHORT_CIRCUIT_ASSIGNMENT_ AssignmentExpression_Await _DEREFERENCE_
   action: process_nullish_coalescing_assignment
 - rule: VariableDeclaration_Await -> BindingIdentifier_Await
-  action: undefined
+  action: process_variable_declaration_no_init
 - rule: VariableDeclaration_Await -> BindingIdentifier_Await Initializer_Await
-  action: undefined
+  action: process_variable_declaration
 - rule: VariableDeclaration_Await -> BindingPattern_Await Initializer_Await
-  action: undefined
+  action: process_variable_declaration_pattern
 - rule: BindingList_Await -> LexicalBinding_Await
   action: process_binding_list_head
 - rule: BindingList_Await -> BindingList_Await COMMA LexicalBinding_Await
@@ -2894,7 +2894,7 @@
 - rule: Statement_Return -> BlockStatement_Return
   action: process_statement
 - rule: Statement_Return -> VariableStatement
-  action: undefined
+  action: process_statement
 - rule: Statement_Return -> EmptyStatement
   action: process_statement
 - rule: Statement_Return -> ExpressionStatement
@@ -3266,7 +3266,7 @@
 - rule: Statement_Yield_Return -> BlockStatement_Yield_Return
   action: process_statement
 - rule: Statement_Yield_Return -> VariableStatement_Yield
-  action: undefined
+  action: process_statement
 - rule: Statement_Yield_Return -> EmptyStatement
   action: process_statement
 - rule: Statement_Yield_Return -> ExpressionStatement_Yield
@@ -3300,7 +3300,7 @@
 - rule: Statement_Await_Return -> BlockStatement_Await_Return
   action: process_statement
 - rule: Statement_Await_Return -> VariableStatement_Await
-  action: undefined
+  action: process_statement
 - rule: Statement_Await_Return -> EmptyStatement
   action: process_statement
 - rule: Statement_Await_Return -> ExpressionStatement_Await
@@ -3328,7 +3328,7 @@
 - rule: Statement_Yield_Await_Return -> BlockStatement_Yield_Await_Return
   action: process_statement
 - rule: Statement_Yield_Await_Return -> VariableStatement_Yield_Await
-  action: undefined
+  action: process_statement
 - rule: Statement_Yield_Await_Return -> EmptyStatement
   action: process_statement
 - rule: Statement_Yield_Await_Return -> ExpressionStatement_Yield_Await
@@ -3565,7 +3565,7 @@
 - rule: BlockStatement_Yield_Return -> Block_Yield_Return
   action: process_block_statement
 - rule: VariableStatement_Yield -> VAR VariableDeclarationList_In_Yield SEMICOLON
-  action: undefined
+  action: process_variable_statement
 - rule: >-
     ExpressionStatement_Yield -> (?![ASYNC (!LINE_TERMINATOR_SEQUENCE) FUNCTION,
     CLASS, FUNCTION, LBRACE, LET LBRACK]) Expression_In_Yield SEMICOLON
@@ -3683,7 +3683,7 @@
 - rule: >-
     VariableStatement_Yield_Await -> VAR VariableDeclarationList_In_Yield_Await
     SEMICOLON
-  action: undefined
+  action: process_variable_statement
 - rule: >-
     ExpressionStatement_Yield_Await -> (?![ASYNC (!LINE_TERMINATOR_SEQUENCE)
     FUNCTION, CLASS, FUNCTION, LBRACE, LET LBRACK]) Expression_In_Yield_Await
@@ -4078,11 +4078,11 @@
 - rule: Block_Yield_Return -> LBRACE _BLOCK_SCOPE_ StatementList_Yield_Return RBRACE
   action: process_block
 - rule: VariableDeclarationList_In_Yield -> VariableDeclaration_In_Yield
-  action: undefined
+  action: process_variable_declaration_list_head
 - rule: >-
     VariableDeclarationList_In_Yield -> VariableDeclarationList_In_Yield COMMA
     VariableDeclaration_In_Yield
-  action: undefined
+  action: process_variable_declaration_list_item
 - rule: IterationStatement_Yield_Return -> DoWhileStatement_Yield_Return
   action: process_iteration_statement
 - rule: IterationStatement_Yield_Return -> WhileStatement_Yield_Return
@@ -4172,12 +4172,12 @@
     StatementList_Yield_Await_Return RBRACE
   action: process_block
 - rule: VariableDeclarationList_In_Yield_Await -> VariableDeclaration_In_Yield_Await
-  action: undefined
+  action: process_variable_declaration_list_head
 - rule: >-
     VariableDeclarationList_In_Yield_Await ->
     VariableDeclarationList_In_Yield_Await COMMA
     VariableDeclaration_In_Yield_Await
-  action: undefined
+  action: process_variable_declaration_list_item
 - rule: IterationStatement_Yield_Await_Return -> DoWhileStatement_Yield_Await_Return
   action: process_iteration_statement
 - rule: IterationStatement_Yield_Await_Return -> WhileStatement_Yield_Await_Return
@@ -4377,11 +4377,11 @@
     StatementList_Return
   action: process_default_clause
 - rule: VariableDeclaration_In_Yield -> BindingIdentifier_Yield
-  action: undefined
+  action: process_variable_declaration_no_init
 - rule: VariableDeclaration_In_Yield -> BindingIdentifier_Yield Initializer_In_Yield
-  action: undefined
+  action: process_variable_declaration
 - rule: VariableDeclaration_In_Yield -> BindingPattern_Yield Initializer_In_Yield
-  action: undefined
+  action: process_variable_declaration_pattern
 - rule: >-
     DoWhileStatement_Yield_Return -> DO _LOOP_START_ Statement_Yield_Return
     _LOOP_BODY_ WHILE LPAREN Expression_In_Yield RPAREN SEMICOLON
@@ -4680,15 +4680,15 @@
     DefaultClause_Await_Return CaseClauses_Await_Return RBRACE
   action: process_case_block_cases_default_cases
 - rule: VariableDeclaration_In_Yield_Await -> BindingIdentifier_Yield_Await
-  action: undefined
+  action: process_variable_declaration_no_init
 - rule: >-
     VariableDeclaration_In_Yield_Await -> BindingIdentifier_Yield_Await
     Initializer_In_Yield_Await
-  action: undefined
+  action: process_variable_declaration
 - rule: >-
     VariableDeclaration_In_Yield_Await -> BindingPattern_Yield_Await
     Initializer_In_Yield_Await
-  action: undefined
+  action: process_variable_declaration_pattern
 - rule: >-
     DoWhileStatement_Yield_Await_Return -> DO _LOOP_START_
     Statement_Yield_Await_Return _LOOP_BODY_ WHILE LPAREN
@@ -5030,11 +5030,11 @@
 - rule: Expression_Yield -> Expression_Yield COMMA AssignmentExpression_Yield
   action: process_comma_operator
 - rule: VariableDeclarationList_Yield -> VariableDeclaration_Yield
-  action: undefined
+  action: process_variable_declaration_list_head
 - rule: >-
     VariableDeclarationList_Yield -> VariableDeclarationList_Yield COMMA
     VariableDeclaration_Yield
-  action: undefined
+  action: process_variable_declaration_list_item
 - rule: LexicalDeclaration_Yield -> LET BindingList_Yield SEMICOLON
   action: process_let_declaration
 - rule: LexicalDeclaration_Yield -> CONST BindingList_Yield SEMICOLON
@@ -5074,11 +5074,11 @@
     AssignmentExpression_Yield_Await
   action: undefined
 - rule: VariableDeclarationList_Yield_Await -> VariableDeclaration_Yield_Await
-  action: undefined
+  action: process_variable_declaration_list_head
 - rule: >-
     VariableDeclarationList_Yield_Await -> VariableDeclarationList_Yield_Await
     COMMA VariableDeclaration_Yield_Await
-  action: undefined
+  action: process_variable_declaration_list_item
 - rule: LexicalDeclaration_Yield_Await -> LET BindingList_Yield_Await SEMICOLON
   action: process_let_declaration
 - rule: LexicalDeclaration_Yield_Await -> CONST BindingList_Yield_Await SEMICOLON
@@ -5252,11 +5252,11 @@
     _NULLISH_SHORT_CIRCUIT_ASSIGNMENT_ AssignmentExpression_Yield _DEREFERENCE_
   action: process_nullish_coalescing_assignment
 - rule: VariableDeclaration_Yield -> BindingIdentifier_Yield
-  action: undefined
+  action: process_variable_declaration_no_init
 - rule: VariableDeclaration_Yield -> BindingIdentifier_Yield Initializer_Yield
-  action: undefined
+  action: process_variable_declaration
 - rule: VariableDeclaration_Yield -> BindingPattern_Yield Initializer_Yield
-  action: undefined
+  action: process_variable_declaration_pattern
 - rule: BindingList_Yield -> LexicalBinding_Yield
   action: process_binding_list_head
 - rule: BindingList_Yield -> BindingList_Yield COMMA LexicalBinding_Yield
@@ -5305,15 +5305,15 @@
     AssignmentExpression_Yield_Await _DEREFERENCE_
   action: process_nullish_coalescing_assignment
 - rule: VariableDeclaration_Yield_Await -> BindingIdentifier_Yield_Await
-  action: undefined
+  action: process_variable_declaration_no_init
 - rule: >-
     VariableDeclaration_Yield_Await -> BindingIdentifier_Yield_Await
     Initializer_Yield_Await
-  action: undefined
+  action: process_variable_declaration
 - rule: >-
     VariableDeclaration_Yield_Await -> BindingPattern_Yield_Await
     Initializer_Yield_Await
-  action: undefined
+  action: process_variable_declaration_pattern
 - rule: BindingList_Yield_Await -> LexicalBinding_Yield_Await
   action: process_binding_list_head
 - rule: >-

--- a/libs/jsruntime/src/llvmir/bridge.rs
+++ b/libs/jsruntime/src/llvmir/bridge.rs
@@ -38,6 +38,7 @@ pub struct RuntimeFunctions {
     print_u32: unsafe extern "C" fn(*mut c_void, u32, *const c_char),
     print_f64: unsafe extern "C" fn(*mut c_void, f64, *const c_char),
     print_value: unsafe extern "C" fn(*mut c_void, *const Value, *const c_char),
+    print_message: unsafe extern "C" fn(*mut c_void, *const c_char),
     launch_debugger: unsafe extern "C" fn(*mut c_void),
 }
 
@@ -63,6 +64,7 @@ impl RuntimeFunctions {
             print_u32: runtime_print_u32,
             print_f64: runtime_print_f64,
             print_value: runtime_print_value,
+            print_message: runtime_print_message,
             launch_debugger: runtime_launch_debugger,
         }
     }
@@ -417,6 +419,14 @@ unsafe extern "C" fn runtime_print_value(
     } else {
         logger::debug!("runtime_print_value: {value:?}: {msg:?}");
     }
+}
+
+unsafe extern "C" fn runtime_print_message(
+    _runtime: *mut c_void,
+    msg: *const std::os::raw::c_char,
+) {
+    let msg = std::ffi::CStr::from_ptr(msg);
+    logger::debug!("runtime_print_value: {msg:?}");
 }
 
 unsafe extern "C" fn runtime_launch_debugger(_runtime: *mut c_void) {

--- a/libs/jsruntime/src/llvmir/bridge.rs
+++ b/libs/jsruntime/src/llvmir/bridge.rs
@@ -32,6 +32,8 @@ pub struct RuntimeFunctions {
     await_promise: unsafe extern "C" fn(*mut c_void, u32, u32),
     resume: unsafe extern "C" fn(*mut c_void, u32),
     emit_promise_resolved: unsafe extern "C" fn(*mut c_void, u32, *const Value),
+    // TODO(perf): `get()` and `set()` are slow... Compute the address of the value by using a base
+    // address and the offset for each property instead of calling these functions.
     get: unsafe extern "C" fn(*mut c_void, u32) -> *const Value,
     set: unsafe extern "C" fn(*mut c_void, u32, *const Value),
     assert: unsafe extern "C" fn(*mut c_void, bool, *const c_char),

--- a/libs/jsruntime/src/llvmir/compiler/bridge.rs
+++ b/libs/jsruntime/src/llvmir/compiler/bridge.rs
@@ -1062,6 +1062,13 @@ impl CompilerBridge {
         }
     }
 
+    #[allow(unused)]
+    pub fn create_print_message(&self, msg: &CStr) {
+        unsafe {
+            compiler_peer_create_print_message(self.0, msg.as_ptr());
+        }
+    }
+
     // debugger
 
     pub fn create_debugger(&self) {
@@ -1670,6 +1677,7 @@ extern "C" {
     // print
 
     fn compiler_peer_create_print_value(peer: CompilerPeer, value: ValueIrPtr, msg: *const c_char);
+    fn compiler_peer_create_print_message(peer: CompilerPeer, msg: *const c_char);
 
     // debugger
 

--- a/libs/jsruntime/src/llvmir/compiler/impl.hh
+++ b/libs/jsruntime/src/llvmir/compiler/impl.hh
@@ -959,6 +959,12 @@ class Compiler {
     builder_->CreateCall(func, {runtime_, value, msg_value});
   }
 
+  void CreatePrintMessage(const char* msg = "") {
+    auto* msg_value = builder_->CreateGlobalString(msg, REG_NAME("runtime.print_message.msg"));
+    auto* func = types_->CreateRuntimePrintMessage();
+    builder_->CreateCall(func, {runtime_, msg_value});
+  }
+
   // debugger
 
   void CreateDebugger() {

--- a/libs/jsruntime/src/llvmir/compiler/peer.cc
+++ b/libs/jsruntime/src/llvmir/compiler/peer.cc
@@ -754,6 +754,10 @@ void compiler_peer_create_print_value(CompilerPeer peer, ValueIrPtr value, const
   IMPL(peer)->CreatePrintValue(LLVM_VALUE(value), msg);
 }
 
+void compiler_peer_create_print_message(CompilerPeer peer, const char* msg) {
+  IMPL(peer)->CreatePrintMessage(msg);
+}
+
 // debugger
 
 void compiler_peer_create_debugger(CompilerPeer peer) {

--- a/libs/jsruntime/src/llvmir/runtime.yaml
+++ b/libs/jsruntime/src/llvmir/runtime.yaml
@@ -112,5 +112,9 @@ functions:
         type: '&Value'
       - name: msg
         type: '&std::ffi::CStr'
+  - name: print_message
+    args:
+      - name: msg
+        type: '&std::ffi::CStr'
   - name: launch_debugger
     args: []

--- a/libs/jsruntime/src/semantics/scope.rs
+++ b/libs/jsruntime/src/semantics/scope.rs
@@ -152,8 +152,8 @@ impl ScopeTreeBuilder {
         self.push(ScopeFlags::FUNCTION, "")
     }
 
-    pub fn set_coroutine(&mut self) {
-        let scope = &mut self.scopes[self.current.index()];
+    pub fn set_coroutine(&mut self, scope_ref: ScopeRef) {
+        let scope = &mut self.scopes[scope_ref.index()];
         debug_assert!(scope.is_function());
         scope.flags.insert(ScopeFlags::COROUTINE);
     }
@@ -222,6 +222,30 @@ impl ScopeTreeBuilder {
         scope.num_locals += 1;
     }
 
+    pub fn add_function_scoped_mutable(&mut self, symbol: Symbol, index: u16) {
+        let scope = &mut self.scopes[self.current.index()];
+        debug_assert!(!scope.is_sorted());
+        scope.bindings.push(Binding {
+            symbol,
+            index,
+            kind: BindingKind::Mutable,
+            flags: BindingFlags::FUNCTION_SCOPED,
+        });
+        scope.num_locals += 1;
+    }
+
+    pub fn add_immutable(&mut self, symbol: Symbol, index: u16) {
+        let scope = &mut self.scopes[self.current.index()];
+        debug_assert!(!scope.is_sorted());
+        scope.bindings.push(Binding {
+            symbol,
+            index,
+            kind: BindingKind::Immutable,
+            flags: BindingFlags::empty(),
+        });
+        scope.num_locals += 1;
+    }
+
     #[allow(unused)]
     pub fn add_hidden(&mut self, symbol: Symbol, index: u16) {
         let scope = &mut self.scopes[self.current.index()];
@@ -233,15 +257,6 @@ impl ScopeTreeBuilder {
             flags: BindingFlags::HIDDEN,
         });
         scope.num_locals += 1;
-    }
-
-    pub fn set_immutable(&mut self, n: u32) {
-        let scope = &mut self.scopes[self.current.index()];
-        debug_assert!(!scope.is_sorted());
-        for binding in scope.bindings.iter_mut().rev().take(n as usize) {
-            debug_assert!(matches!(binding.kind, BindingKind::Mutable));
-            binding.kind = BindingKind::Immutable;
-        }
     }
 
     pub fn add_capture(&mut self, scope_ref: ScopeRef, symbol: Symbol) {
@@ -438,6 +453,10 @@ impl Binding {
         self.flags.contains(BindingFlags::CAPTURED)
     }
 
+    pub fn is_function_scoped(&self) -> bool {
+        self.flags.contains(BindingFlags::FUNCTION_SCOPED)
+    }
+
     fn set_captured(&mut self) {
         self.flags.insert(BindingFlags::CAPTURED)
     }
@@ -451,6 +470,9 @@ impl std::fmt::Display for Binding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.is_captured() {
             write!(f, "*")?;
+        }
+        if self.is_function_scoped() {
+            write!(f, "^")?;
         }
         if self.is_hidden() {
             write!(f, "?")?;
@@ -478,7 +500,8 @@ pub enum BindingKind {
 bitflags! {
     #[derive(Debug)]
     struct BindingFlags: u8 {
-        const CAPTURED = 0b00000001;
-        const HIDDEN   = 0b10000000;
+        const CAPTURED        = 1 << 0;
+        const FUNCTION_SCOPED = 1 << 1;
+        const HIDDEN          = 1 << 7;
     }
 }

--- a/libs/jsruntime/src/semantics/scope.rs
+++ b/libs/jsruntime/src/semantics/scope.rs
@@ -1,3 +1,7 @@
+// TODO(feat): Symbols in a scope must be unique
+//   10.2.11 FunctionDeclarationInstantiation ( func, argumentsList )
+//   16.1.7 GlobalDeclarationInstantiation ( script, env )
+
 use bitflags::bitflags;
 
 use super::Locator;

--- a/libs/jsruntime/tests/modules/variable_statement.mjs
+++ b/libs/jsruntime/tests/modules/variable_statement.mjs
@@ -1,3 +1,3 @@
 var x = 1;
-print(await x);
-print(await x);
+print(await x); ///=1
+print(await x); ///=1

--- a/libs/jsruntime/tests/modules/variable_statement.mjs
+++ b/libs/jsruntime/tests/modules/variable_statement.mjs
@@ -1,0 +1,3 @@
+var x = 1;
+print(await x);
+print(await x);

--- a/libs/jsruntime/tests/scripts/variable_statement.js
+++ b/libs/jsruntime/tests/scripts/variable_statement.js
@@ -1,0 +1,3 @@
+print(a); ///=undefined
+var a = 1;
+print(a); ///=1

--- a/libs/jsruntime/tests/scripts/variable_statement_in_block.js
+++ b/libs/jsruntime/tests/scripts/variable_statement_in_block.js
@@ -1,0 +1,5 @@
+print(a); ///=undefined
+{
+  var a = 1;
+}
+print(a); ///=1

--- a/libs/jsruntime/tests/scripts/variable_statement_in_block_in_function.js
+++ b/libs/jsruntime/tests/scripts/variable_statement_in_block_in_function.js
@@ -1,0 +1,9 @@
+f();
+
+function f() {
+  print(a); ///=undefined
+  {
+    var a = 1;
+  }
+  print(a); ///=1
+}

--- a/libs/jsruntime/tests/scripts/variable_statement_in_function.js
+++ b/libs/jsruntime/tests/scripts/variable_statement_in_function.js
@@ -1,0 +1,7 @@
+f();
+
+function f() {
+  print(a); ///=undefined
+  var a = 1;
+  print(a); ///=1
+}

--- a/libs/jsruntime/tests/scripts/variable_statement_overwrite.js
+++ b/libs/jsruntime/tests/scripts/variable_statement_overwrite.js
@@ -1,0 +1,5 @@
+print(a); ///=undefined
+var a = 1;
+print(a); ///=1
+var a = 2;
+print(a); ///=2

--- a/libs/jsruntime/tests/scripts/variable_statement_overwrite_in_block.js
+++ b/libs/jsruntime/tests/scripts/variable_statement_overwrite_in_block.js
@@ -1,0 +1,9 @@
+print(a); ///=undefined
+{
+  var a = 1;
+}
+print(a); ///=1
+{
+  var a = 2;
+}
+print(a); ///=2

--- a/libs/jsruntime/tests/scripts/variable_statement_overwrite_in_function.js
+++ b/libs/jsruntime/tests/scripts/variable_statement_overwrite_in_function.js
@@ -1,0 +1,9 @@
+f();
+
+function f() {
+  print(a); ///=undefined
+  var a = 1;
+  print(a); ///=1
+  var a = 2;
+  print(a); ///=2
+}


### PR DESCRIPTION
TODO:

- top-level functions are defined as properties of the global object
  - calling a top-level function causes a runtime function call that makes the JavaScript function invocation slower
  - check the Bencher report to see how slow it was 
- as the specification says, symbols in each scope must be unique but this is not supported currently
- for-var statement is not supported
  - will be implemented in a separate PR in the future